### PR TITLE
Add a condition to remove_repeated_chars() to address an edge case

### DIFF
--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -497,7 +497,7 @@ class LTTextContainer(LTExpandableContainer[LTItemT], LTText):
         char_objs = []
         previous_obj = None
         for obj in self:                    
-            if isinstance(obj, LTText):
+            if isinstance(obj, LTText) and not isinstance(obj, LTAnno):
                 if previous_obj is None:
                     char_objs.append(obj)
                     previous_obj = obj


### PR DESCRIPTION

LTAnno is a child class inherited from LTText but it does not have boundaries or coordinates. It will raise exception if the input instance is LTAnno and we try to get its coordinate to calculate IOU. So need to add a constraint here to avoid that exception. Look to the LTAnno  class if you want to see more details.